### PR TITLE
update to Guzzle 6

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": true
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}

--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-{
-  "generalSettings": {
-    "shouldScanRepo": true
-  },
-  "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure"
-  }
-}

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": false
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 SIL International
+Copyright (c) 2020 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,12 @@
   "license": "MIT",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^5.3.1 || ^6.5.3",
     "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "ext-json": "*",
+    "phpunit/phpunit": "~4.0",
+    "roave/security-advisories": "dev-master"
   },
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["crashplan","crash-plan"],
   "license": "MIT",
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=7.2.0",
     "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,8 @@
   "license": "MIT",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^5.3.1",
-    "guzzlehttp/guzzle-services": "*",
-    "guzzlehttp/retry-subscriber": "*",
-    "guzzlehttp/log-subscriber": "*"
+    "guzzlehttp/guzzle": "^5.3.1 || ^6.5.3",
+    "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,6 @@ class Client extends GuzzleClient
     {
         // Apply some defaults.
         $config += [
-            'max_retries'      => 3,
             'description_path' => __DIR__ . '/crashplan-api.php',
         ];
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,6 @@ namespace Crashplan;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
-use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
 
 /**
  * Partial Crashplan API client implemented with Guzzle.
@@ -59,15 +58,6 @@ class Client extends GuzzleClient
             ? $config['http_client_options']
             : [];
         $client = new HttpClient($clientOptions);
-
-        // Attach request retry logic.
-        $client->getEmitter()->attach(new RetrySubscriber([
-            'max' => $config['max_retries'],
-            'filter' => RetrySubscriber::createChainFilter([
-                RetrySubscriber::createStatusFilter(),
-                RetrySubscriber::createCurlFilter(),
-            ]),
-        ]));
 
         return $client;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -29,20 +29,25 @@ class Client extends GuzzleClient
             'description_path' => __DIR__ . '/crashplan-api.php',
         ];
 
+        // Ensure that the credentials are set.
+        $config = $this->applyCredentials($config);
+
         // Create the Crashplan client.
         parent::__construct(
             $this->getHttpClientFromConfig($config),
             $this->getDescriptionFromConfig($config),
+            null,
+            null,
+            null,
             $config
         );
 
-        // Ensure that the credentials are set.
-        $this->applyCredentials($config);
-
         // Ensure that ApiVersion is set.
         $this->setConfig(
-            'defaults/ApiVersion',
-            $this->getDescription()->getApiVersion()
+            'defaults',
+            [
+                'ApiVersion' => $this->getDescription()->getApiVersion()
+            ]
         );
     }
 
@@ -97,8 +102,11 @@ class Client extends GuzzleClient
         }
 
         // Set credentials for authentication based on Crashplan's requirements.
-        $this->getHttpClient()->setDefaultOption('auth', [
+        $config['auth'] = [
             $config['apiuser'], $config['apipass']
-        ]);
+        ];
+
+        // Return new config array with credentials for authentication based on Jira's requirements.
+        return $config;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -68,7 +68,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call list users and make sure we get back the user we expect from mock
         $users = $client->listUsers(['email' => 'multiple_results@domain.org']);
@@ -109,7 +109,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->getUser(['userId' => 123]);
@@ -148,7 +148,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->addUser(
@@ -196,7 +196,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $client = $this->getMockClient($mockBody, 200);
+        $client = $this->getMockClient($mockBody);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->updateUser(
@@ -232,11 +232,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    /**
-     * @param $mockBody
-     * @return Client
-     */
-    private function getMockClient($mockBody, $responseCode)
+    private function getMockClient(string $mockBody, int $responseCode = 200) : Client
     {
         $config = include 'config-test.php';
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,88 +2,73 @@
 namespace tests;
 
 use Crashplan\Client;
-use GuzzleHttp\Subscriber\Mock;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
     public function testListUsersByEmail()
     {
-        $config = include 'config-test.php';
-
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "metadata" => [
-                        "timestamp" => "2015-03-03T10:42:25.649-05:00",
-                        "params" => [
-                            "email" => "test_user@domain.org"
-                        ]
+        $mockBody = json_encode([
+            "metadata" => [
+                "timestamp" => "2015-03-03T10:42:25.649-05:00",
+                "params" => [
+                    "email" => "test_user@domain.org"
+                ],
+            ],
+            "data" => [
+                "totalCount" => 2,
+                "users" => [
+                    [
+                        "userId" => 123,
+                        "userUid" => "53c47723asdf2f1f1",
+                        "status" => "Active",
+                        "username" => "test_user",
+                        "email" => "test_user@domain.org",
+                        "firstName" => "Test",
+                        "lastName" => "User",
+                        "quotaInBytes" => -1,
+                        "orgId" => 558,
+                        "orgUid" => "678045511115890321",
+                        "orgName" => "Development_API",
+                        "active" => true,
+                        "blocked" => false,
+                        "emailPromo" => true,
+                        "invited" => false,
+                        "orgType" => "ENTERPRISE",
+                        "usernameIsAnEmail" => false,
+                        "creationDate" => "2015-01-13T20:53:49.133-05:00",
+                        "modificationDate" => "2015-02-25T14:59:34.216-05:00",
+                        "passwordReset" => false
                     ],
-                    "data" => [
-                        "totalCount" => 2,
-                        "users" => [
-                            [
-                                "userId" => 123,
-                                "userUid" => "53c47723asdf2f1f1",
-                                "status" => "Active",
-                                "username" => "test_user",
-                                "email" => "test_user@domain.org",
-                                "firstName" => "Test",
-                                "lastName" => "User",
-                                "quotaInBytes" => -1,
-                                "orgId" => 558,
-                                "orgUid" => "678045511115890321",
-                                "orgName" => "Development_API",
-                                "active" => true,
-                                "blocked" => false,
-                                "emailPromo" => true,
-                                "invited" => false,
-                                "orgType" => "ENTERPRISE",
-                                "usernameIsAnEmail" => false,
-                                "creationDate" => "2015-01-13T20:53:49.133-05:00",
-                                "modificationDate" => "2015-02-25T14:59:34.216-05:00",
-                                "passwordReset" => false
-                            ],
-                            [
-                                "userId" => 456,
-                                "userUid" => "c0cd9casdf643880",
-                                "status" => "Active",
-                                "username" => "different_user",
-                                "email" => "test_user@domain.org",
-                                "firstName" => "User",
-                                "lastName" => "Staging",
-                                "quotaInBytes" => -1,
-                                "orgId" => 559,
-                                "orgUid" => "678768123909624593",
-                                "orgName" => "Staging",
-                                "active" => true,
-                                "blocked" => false,
-                                "emailPromo" => true,
-                                "invited" => false,
-                                "orgType" => "ENTERPRISE",
-                                "usernameIsAnEmail" => false,
-                                "creationDate" => "2015-03-02T15:16:04.915-05:00",
-                                "modificationDate" => "2015-03-02T15:16:39.689-05:00",
-                                "passwordReset" => false
-                            ]
-                        ]
-                    ]
-                ]
-            )
-        );
+                    [
+                        "userId" => 456,
+                        "userUid" => "c0cd9casdf643880",
+                        "status" => "Active",
+                        "username" => "different_user",
+                        "email" => "test_user@domain.org",
+                        "firstName" => "User",
+                        "lastName" => "Staging",
+                        "quotaInBytes" => -1,
+                        "orgId" => 559,
+                        "orgUid" => "678768123909624593",
+                        "orgName" => "Staging",
+                        "active" => true,
+                        "blocked" => false,
+                        "emailPromo" => true,
+                        "invited" => false,
+                        "orgType" => "ENTERPRISE",
+                        "usernameIsAnEmail" => false,
+                        "creationDate" => "2015-03-02T15:16:04.915-05:00",
+                        "modificationDate" => "2015-03-02T15:16:39.689-05:00",
+                        "passwordReset" => false
+                    ],
+                ],
+            ],
+        ]);
 
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call list users and make sure we get back the user we expect from mock
         $users = $client->listUsers(['email' => 'multiple_results@domain.org']);
@@ -95,51 +80,36 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = json_encode([
+            "metadata" => [
+                "timestamp" => "2015-03-03T11:34:41.861-05:00",
+                "params" => []
+            ],
+            "data" => [
+                "userId" => 123,
+                "userUid" => "53c47asdef62f1f1",
+                "status" => "Active",
+                "username" => "test_user",
+                "email" => "test_user@domain.org",
+                "firstName" => "Test",
+                "lastName" => "User",
+                "quotaInBytes" => -1,
+                "orgId" => 558,
+                "orgUid" => "678012345665890321",
+                "orgName" => "Development_API",
+                "active" => true,
+                "blocked" => false,
+                "emailPromo" => true,
+                "invited" => false,
+                "orgType" => "ENTERPRISE",
+                "usernameIsAnEmail" => false,
+                "creationDate" => "2015-01-13T20:53:49.133-05:00",
+                "modificationDate" => "2015-02-25T14:59:34.216-05:00",
+                "passwordReset" => false
+            ],
+        ]);
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "metadata" => [
-                        "timestamp" => "2015-03-03T11:34:41.861-05:00",
-                        "params" => []
-                    ],
-                    "data" => [
-                        "userId" => 123,
-                        "userUid" => "53c47asdef62f1f1",
-                        "status" => "Active",
-                        "username" => "test_user",
-                        "email" => "test_user@domain.org",
-                        "firstName" => "Test",
-                        "lastName" => "User",
-                        "quotaInBytes" => -1,
-                        "orgId" => 558,
-                        "orgUid" => "678012345665890321",
-                        "orgName" => "Development_API",
-                        "active" => true,
-                        "blocked" => false,
-                        "emailPromo" => true,
-                        "invited" => false,
-                        "orgType" => "ENTERPRISE",
-                        "usernameIsAnEmail" => false,
-                        "creationDate" => "2015-01-13T20:53:49.133-05:00",
-                        "modificationDate" => "2015-02-25T14:59:34.216-05:00",
-                        "passwordReset" => false
-                    ]
-                ]
-            )
-        );
-
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->getUser(['userId' => 123]);
@@ -149,51 +119,36 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testAddUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = json_encode([
+            "metadata" => [
+                "timestamp" => "2015-03-03T15:25:45.630-05:00",
+                "params" => []
+            ],
+            "data" => [
+                "userId" => 123,
+                "userUid" => "e28fe5gadfw4c0e6",
+                "status" => "Active",
+                "username" => "test_user",
+                "email" => "test_user@domain.com",
+                "firstName" => "Test",
+                "lastName" => "User",
+                "quotaInBytes" => -1,
+                "orgId" => 503,
+                "orgUid" => "678914523462070292",
+                "orgName" => "Staging",
+                "active" => true,
+                "blocked" => false,
+                "emailPromo" => true,
+                "invited" => false,
+                "orgType" => "ENTERPRISE",
+                "usernameIsAnEmail" => null,
+                "creationDate" => "2015-03-03T15:25:45.523-05:00",
+                "modificationDate" => "2015-03-03T15:25:45.560-05:00",
+                "passwordReset" => false
+            ],
+        ]);
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "metadata" => [
-                        "timestamp" => "2015-03-03T15:25:45.630-05:00",
-                        "params" => []
-                    ],
-                    "data" => [
-                        "userId" => 123,
-                        "userUid" => "e28fe5gadfw4c0e6",
-                        "status" => "Active",
-                        "username" => "test_user",
-                        "email" => "test_user@domain.com",
-                        "firstName" => "Test",
-                        "lastName" => "User",
-                        "quotaInBytes" => -1,
-                        "orgId" => 503,
-                        "orgUid" => "678914523462070292",
-                        "orgName" => "Staging",
-                        "active" => true,
-                        "blocked" => false,
-                        "emailPromo" => true,
-                        "invited" => false,
-                        "orgType" => "ENTERPRISE",
-                        "usernameIsAnEmail" => null,
-                        "creationDate" => "2015-03-03T15:25:45.523-05:00",
-                        "modificationDate" => "2015-03-03T15:25:45.560-05:00",
-                        "passwordReset" => false
-                    ]
-                ]
-            )
-        );
-
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->addUser(
@@ -212,51 +167,36 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = json_encode([
+            "metadata" => [
+                "timestamp" => "2015-03-03T15:25:45.630-05:00",
+                "params" => []
+            ],
+            "data" => [
+                "userId" => 123,
+                "userUid" => "e28fe5gadfw4c0e6",
+                "status" => "Active",
+                "username" => "test_user",
+                "email" => "test_user@domain.com",
+                "firstName" => "Test",
+                "lastName" => "User",
+                "quotaInBytes" => -1,
+                "orgId" => 503,
+                "orgUid" => "678914523462070292",
+                "orgName" => "Staging",
+                "active" => true,
+                "blocked" => false,
+                "emailPromo" => true,
+                "invited" => false,
+                "orgType" => "ENTERPRISE",
+                "usernameIsAnEmail" => null,
+                "creationDate" => "2015-03-03T15:25:45.523-05:00",
+                "modificationDate" => "2015-03-03T15:25:45.560-05:00",
+                "passwordReset" => false
+            ],
+        ]);
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory(
-            json_encode(
-                [
-                    "metadata" => [
-                        "timestamp" => "2015-03-03T15:25:45.630-05:00",
-                        "params" => []
-                    ],
-                    "data" => [
-                        "userId" => 123,
-                        "userUid" => "e28fe5gadfw4c0e6",
-                        "status" => "Active",
-                        "username" => "test_user",
-                        "email" => "test_user@domain.com",
-                        "firstName" => "Test",
-                        "lastName" => "User",
-                        "quotaInBytes" => -1,
-                        "orgId" => 503,
-                        "orgUid" => "678914523462070292",
-                        "orgName" => "Staging",
-                        "active" => true,
-                        "blocked" => false,
-                        "emailPromo" => true,
-                        "invited" => false,
-                        "orgType" => "ENTERPRISE",
-                        "usernameIsAnEmail" => null,
-                        "creationDate" => "2015-03-03T15:25:45.523-05:00",
-                        "modificationDate" => "2015-03-03T15:25:45.560-05:00",
-                        "passwordReset" => false
-                    ]
-                ]
-            )
-        );
-
-        $mock = new Mock(
-            [
-                new Response(200, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 200);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->updateUser(
@@ -276,20 +216,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testDeactivateUser()
     {
-        $config = include 'config-test.php';
+        $mockBody = '{}';
 
-        $client = new Client($config);
-
-        $mockBody = Stream::factory('{}');
-
-        $mock = new Mock(
-            [
-                new Response(204, [], $mockBody),
-            ]
-        );
-
-        // Add the mock subscriber to the client.
-        $client->getHttpClient()->getEmitter()->attach($mock);
+        $client = $this->getMockClient($mockBody, 204);
 
         // Call get user and make sure we get back the user we expect from mock
         $user = $client->deactivateUser(
@@ -301,5 +230,26 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(204, $user['statusCode']);
 
+    }
+
+    /**
+     * @param $mockBody
+     * @return Client
+     */
+    private function getMockClient($mockBody, $responseCode)
+    {
+        $config = include 'config-test.php';
+
+        $mockHandler = new MockHandler([
+            new Response($responseCode, [], $mockBody),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+
+        return new Client(array_merge([
+            'http_client_options' => [
+                'handler' => $handlerStack,
+            ]
+        ], $config));
     }
 }


### PR DESCRIPTION
required changes:
- `guzzlehttp/retry-subscriber` was removed, so no automatic API retries
- http client is now immutable, so credentials are applied to config before client creation 
- `setConfig` changed how arguments are passed (slash-separated to nested array)
- test mocks are created differently